### PR TITLE
Change the hashmap api a bit

### DIFF
--- a/include/cutils/hashmap.h
+++ b/include/cutils/hashmap.h
@@ -38,7 +38,7 @@
 #include <stdlib.h>
 
 /* We need to keep keys and values. */
-struct hashmap_element_s {
+struct hashmap_element {
     const char *key;
     size_t key_len;
     int in_use;
@@ -47,23 +47,23 @@ struct hashmap_element_s {
 
 /* A hashmap has some maximum size and current size, as well as the data to
  * hold. */
-struct hashmap_s {
+typedef struct {
     size_t table_size;
     size_t size;
-    struct hashmap_element_s *data;
-};
+    struct hashmap_element *data;
+} hashmap_t;
 
 
 /**
  *  Create a hashmap.
  *
- *  @param initial_size The initial size of the hashmap. **Must be a power of two.**
+ *  @param initial_size The initial size of the hashmap.
  *  @param out_hashmap  The storage for the created hashmap.
  *
  *  @return On success 0 is returned.
+ *          If too large or memory failure non-zero is returned.
  */
-int hashmap_create(const size_t initial_size,
-                   struct hashmap_s *const out_hashmap);
+int hashmap_create(size_t initial_size, hashmap_t *const out_hashmap);
 
 
 /**
@@ -80,8 +80,8 @@ int hashmap_create(const size_t initial_size,
  *
  *  @return On success 0 is returned.
  */
-int hashmap_put(struct hashmap_s *const hashmap, const char *const key,
-                const size_t len, void *const value);
+int hashmap_put(hashmap_t *const hashmap, const char *const key,
+                size_t len, void *const value);
 
 
 /**
@@ -93,8 +93,8 @@ int hashmap_put(struct hashmap_s *const hashmap, const char *const key,
  *
  *  @return The previously set element, or NULL if none exists.
  */
-void *hashmap_get(const struct hashmap_s *const hashmap,
-                  const char *const key, const size_t len);
+void *hashmap_get(const hashmap_t *const hashmap,
+                  const char *const key, size_t len);
 
 
 /**
@@ -106,12 +106,13 @@ void *hashmap_get(const struct hashmap_s *const hashmap,
  *
  *  @return On success 0 is returned.
  */
-int hashmap_remove(struct hashmap_s *const hashmap,
-                   const char *const key, const size_t len);
+int hashmap_remove(hashmap_t *const hashmap,
+                   const char *const key, size_t len);
 
 
 /**
- *  Remove an element from the hashmap.
+ *  Remove an element from the hashmap and return the key.  This call provides
+ *  a way to get the key back so it can be freed.
  *
  *  @param hashmap The hashmap to remove from.
  *  @param key     The string key to use.
@@ -120,8 +121,8 @@ int hashmap_remove(struct hashmap_s *const hashmap,
  *  @return On success the original stored key pointer is returned,
  *          on failure NULL is returned.
  */
-const char *hashmap_remove_and_return_key(struct hashmap_s *const hashmap,
-                                          const char *const key, const size_t len);
+const char *hashmap_remove_and_return_key(hashmap_t *const hashmap,
+                                          const char *const key, size_t len);
 
 
 /**
@@ -134,7 +135,7 @@ const char *hashmap_remove_and_return_key(struct hashmap_s *const hashmap,
  *  @return If the entire hashmap was iterated then 0 is returned. Otherwise if
  *          the callback function f returned non-zero then non-zero is returned.
  */
-int hashmap_iterate(const struct hashmap_s *const hashmap,
+int hashmap_iterate(const hashmap_t *const hashmap,
                     int (*f)(void *const context, void *const value),
                     void *const context);
 
@@ -152,8 +153,8 @@ int hashmap_iterate(const struct hashmap_s *const hashmap,
  *          If the callback function returns -1, the current item is removed
  *              and iteration continues.
  */
-int hashmap_iterate_pairs(struct hashmap_s *const hashmap,
-                          int (*f)(void *const, struct hashmap_element_s *const),
+int hashmap_iterate_pairs(hashmap_t *const hashmap,
+                          int (*f)(void *const, struct hashmap_element *const),
                           void *const context);
 
 
@@ -164,7 +165,7 @@ int hashmap_iterate_pairs(struct hashmap_s *const hashmap,
  *
  *  @return The size of the hashmap.
  */
-size_t hashmap_num_entries(const struct hashmap_s *const hashmap);
+size_t hashmap_num_entries(const hashmap_t *const hashmap);
 
 
 /**
@@ -172,7 +173,7 @@ size_t hashmap_num_entries(const struct hashmap_s *const hashmap);
  *
  * @param hashmap The hashmap to destroy.
  */
-void hashmap_destroy(struct hashmap_s *const hashmap);
+void hashmap_destroy(hashmap_t *const hashmap);
 
 
 #endif

--- a/include/cutils/hashmap.h
+++ b/include/cutils/hashmap.h
@@ -57,11 +57,14 @@ typedef struct {
 /**
  *  Create a hashmap.
  *
+ *  Optional if the hashmap_t object is set to zero.
+ *
  *  @param initial_size The initial size of the hashmap.
  *  @param out_hashmap  The storage for the created hashmap.
  *
  *  @return On success 0 is returned.
- *          If too large or memory failure non-zero is returned.
+ *          -1 is returned if an input is invalid
+ *          -2 is returned if there was a memory failure
  */
 int hashmap_create(size_t initial_size, hashmap_t *const out_hashmap);
 
@@ -79,6 +82,9 @@ int hashmap_create(size_t initial_size, hashmap_t *const out_hashmap);
  *  @param value   The value to insert.
  *
  *  @return On success 0 is returned.
+ *          -1 is returned if the input is invalid
+ *          -2 is returned if there was a memory failure
+ *          -3 is returned if there was not space due to hash collisions
  */
 int hashmap_put(hashmap_t *const hashmap, const char *const key,
                 size_t len, void *const value);
@@ -104,7 +110,8 @@ void *hashmap_get(const hashmap_t *const hashmap,
  *  @param key     The string key to use.
  *  @param len     The length of the string key.
  *
- *  @return On success 0 is returned.
+ *  @return 0 is returned if the element was removed
+ *          1 is returned if no element was found to remove
  */
 int hashmap_remove(hashmap_t *const hashmap,
                    const char *const key, size_t len);
@@ -126,7 +133,7 @@ const char *hashmap_remove_and_return_key(hashmap_t *const hashmap,
 
 
 /**
- *  Iterate over all the elements in a hashmap.
+ *  Iterate over all the values in a hashmap.
  *
  *  @param hashmap The hashmap to iterate over.
  *  @param f       The function pointer to call on each element.
@@ -154,7 +161,7 @@ int hashmap_iterate(const hashmap_t *const hashmap,
  *              and iteration continues.
  */
 int hashmap_iterate_pairs(hashmap_t *const hashmap,
-                          int (*f)(void *const, struct hashmap_element *const),
+                          int (*f)(void *const context, struct hashmap_element *const),
                           void *const context);
 
 

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,7 @@ inc = include_directories(inc_base)
 sources = ['src/base64.c',
            'src/file.c',
            'src/hashmap.c',
+           'src/hashmap_crc.c',
            'src/memory.c',
            'src/nl_ctype.c',
            'src/printf.c',
@@ -58,14 +59,15 @@ if not meson.is_subproject()
 
   cunit_dep = dependency('cunit')
 
-  tests = [['test base64',     'test_base64'],
-           ['test file',       'test_file'],
-           ['test hashmap',    'test_hashmap'],
-           ['test memory',     'test_memory'],
-           ['test printf',     'test_printf'],
-           ['test nl_strings', 'test_nl_strings'],
-           ['test strings',    'test_strings'],
-           ['test xxd',        'test_xxd']]
+  tests = [['test base64',            'test_base64'],
+           ['test file',              'test_file'],
+           ['test hashmap',           'test_hashmap'],
+           ['test hashmap collision', 'test_hashmap_collision'],
+           ['test memory',            'test_memory'],
+           ['test printf',            'test_printf'],
+           ['test nl_strings',        'test_nl_strings'],
+           ['test strings',           'test_strings'],
+           ['test xxd',               'test_xxd']]
 
   foreach test : tests
     test(test[0],

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -41,15 +41,18 @@
 
 #define HASHMAP_MAX_CHAIN_LENGTH (8)
 #define HASHMAP_MAX_SIZE (1 << 31) /* Up to 2G entries work */
+#define HASHMAP_DEFAULT_SIZE (16)
 
 /*----------------------------------------------------------------------------*/
 /*                            Function Prototypes                             */
 /*----------------------------------------------------------------------------*/
-static uint32_t hashmap_crc32_helper(const char *const s,
-                                     const size_t len);
-static uint32_t hashmap_hash_helper_int_helper(const hashmap_t *const m,
-                                               const char *const keystring,
-                                               const size_t len);
+
+extern uint32_t hashmap_crc32_helper(const char *const s, const size_t len);
+
+
+static size_t hashmap_hash_helper_int_helper(const hashmap_t *const m,
+                                             const char *const keystring,
+                                             const size_t len);
 static int hashmap_match_helper(const struct hashmap_element *const element,
                                 const char *const key,
                                 const size_t len);
@@ -69,23 +72,23 @@ static size_t num_to_pow2(size_t num);
 
 int hashmap_create(size_t initial_size, hashmap_t *const out_hashmap)
 {
-    out_hashmap->table_size = initial_size;
-    out_hashmap->size = 0;
-
-    /* Only exit if the number is too large. */
-    if (HASHMAP_MAX_SIZE < initial_size) {
-        return 1;
+    /* Exit if the number is too large, or if we'd crash. */
+    if (!out_hashmap || (HASHMAP_MAX_SIZE < initial_size)) {
+        return -1;
     }
 
-    /* Simplify and assume there will be 1 vs. failing and returning. */
+    /* Simplify and assume there will be a default. */
     if (0 == initial_size) {
-        initial_size = 1;
+        initial_size = HASHMAP_DEFAULT_SIZE;
     }
     initial_size = num_to_pow2(initial_size);
 
+    out_hashmap->table_size = initial_size;
+    out_hashmap->size = 0;
+
     out_hashmap->data = calloc(initial_size, sizeof(struct hashmap_element));
     if (!out_hashmap->data) {
-        return 1;
+        return -2;
     }
 
     return 0;
@@ -96,11 +99,25 @@ int hashmap_put(hashmap_t *const m, const char *const key,
                 size_t len, void *const value)
 {
     uint32_t index = 0;
+    int rv = 0;
+
+    if (!m) {
+        return -1;
+    }
+
+    /* Make a new hashmap if this is the first put */
+    if (!m->data) {
+        int rv = hashmap_create(0, m);
+        if (rv) {
+            return rv;
+        }
+    }
 
     /* Find a place to put our value. */
     while (!hashmap_hash_helper(m, key, len, &index)) {
-        if (hashmap_rehash_helper(m)) {
-            return 1;
+        rv = hashmap_rehash_helper(m);
+        if (rv) {
+            return rv;
         }
     }
 
@@ -124,6 +141,11 @@ void *hashmap_get(const hashmap_t *const m, const char *const key, size_t len)
 {
     size_t curr;
 
+    /* Return empty if the hash is not created */
+    if (!m || !m->data) {
+        return NULL;
+    }
+
     /* Find data location */
     curr = hashmap_hash_helper_int_helper(m, key, len);
 
@@ -146,6 +168,11 @@ void *hashmap_get(const hashmap_t *const m, const char *const key, size_t len)
 int hashmap_remove(hashmap_t *const m, const char *const key, size_t len)
 {
     size_t curr;
+
+    /* Nothing to remove. */
+    if (!m || !m->data) {
+        return 1;
+    }
 
     /* Find key */
     curr = hashmap_hash_helper_int_helper(m, key, len);
@@ -177,6 +204,11 @@ const char *hashmap_remove_and_return_key(hashmap_t *const m,
 {
     size_t curr;
 
+    /* Nothing to remove. */
+    if (!m || !m->data) {
+        return NULL;
+    }
+
     /* Find key */
     curr = hashmap_hash_helper_int_helper(m, key, len);
 
@@ -207,6 +239,10 @@ const char *hashmap_remove_and_return_key(hashmap_t *const m,
 int hashmap_iterate(const hashmap_t *const m,
                     int (*f)(void *const, void *const), void *const context)
 {
+    if (!m) {
+        return 0;
+    }
+
     /* Linear probing */
     for (size_t i = 0; i < m->table_size; i++) {
         if (m->data[i].in_use) {
@@ -223,6 +259,10 @@ int hashmap_iterate_pairs(hashmap_t *const m,
                           int (*f)(void *const, struct hashmap_element *const),
                           void *const context)
 {
+    if (!m) {
+        return 0;
+    }
+
     /* Linear probing */
     for (size_t i = 0; i < m->table_size; i++) {
         struct hashmap_element *p = &m->data[i];
@@ -248,14 +288,22 @@ int hashmap_iterate_pairs(hashmap_t *const m,
 
 void hashmap_destroy(hashmap_t *const m)
 {
-    free(m->data);
-    memset(m, 0, sizeof(hashmap_t));
+    if (m) {
+        if (m->data) {
+            free(m->data);
+        }
+        memset(m, 0, sizeof(hashmap_t));
+    }
 }
 
 
 size_t hashmap_num_entries(const hashmap_t *const m)
 {
-    return m->size;
+    if (m) {
+        return m->size;
+    }
+
+    return 0;
 }
 
 
@@ -264,76 +312,9 @@ size_t hashmap_num_entries(const hashmap_t *const m)
 /*----------------------------------------------------------------------------*/
 
 
-static uint32_t hashmap_crc32_helper(const char *const s, const size_t len)
-{
-    uint32_t crc32val = 0;
-
-    // Using polynomial 0x11EDC6F41 to match SSE 4.2's crc function.
-    static const uint32_t crc32_tab[] = {
-        0x00000000U, 0xF26B8303U, 0xE13B70F7U, 0x1350F3F4U, 0xC79A971FU,
-        0x35F1141CU, 0x26A1E7E8U, 0xD4CA64EBU, 0x8AD958CFU, 0x78B2DBCCU,
-        0x6BE22838U, 0x9989AB3BU, 0x4D43CFD0U, 0xBF284CD3U, 0xAC78BF27U,
-        0x5E133C24U, 0x105EC76FU, 0xE235446CU, 0xF165B798U, 0x030E349BU,
-        0xD7C45070U, 0x25AFD373U, 0x36FF2087U, 0xC494A384U, 0x9A879FA0U,
-        0x68EC1CA3U, 0x7BBCEF57U, 0x89D76C54U, 0x5D1D08BFU, 0xAF768BBCU,
-        0xBC267848U, 0x4E4DFB4BU, 0x20BD8EDEU, 0xD2D60DDDU, 0xC186FE29U,
-        0x33ED7D2AU, 0xE72719C1U, 0x154C9AC2U, 0x061C6936U, 0xF477EA35U,
-        0xAA64D611U, 0x580F5512U, 0x4B5FA6E6U, 0xB93425E5U, 0x6DFE410EU,
-        0x9F95C20DU, 0x8CC531F9U, 0x7EAEB2FAU, 0x30E349B1U, 0xC288CAB2U,
-        0xD1D83946U, 0x23B3BA45U, 0xF779DEAEU, 0x05125DADU, 0x1642AE59U,
-        0xE4292D5AU, 0xBA3A117EU, 0x4851927DU, 0x5B016189U, 0xA96AE28AU,
-        0x7DA08661U, 0x8FCB0562U, 0x9C9BF696U, 0x6EF07595U, 0x417B1DBCU,
-        0xB3109EBFU, 0xA0406D4BU, 0x522BEE48U, 0x86E18AA3U, 0x748A09A0U,
-        0x67DAFA54U, 0x95B17957U, 0xCBA24573U, 0x39C9C670U, 0x2A993584U,
-        0xD8F2B687U, 0x0C38D26CU, 0xFE53516FU, 0xED03A29BU, 0x1F682198U,
-        0x5125DAD3U, 0xA34E59D0U, 0xB01EAA24U, 0x42752927U, 0x96BF4DCCU,
-        0x64D4CECFU, 0x77843D3BU, 0x85EFBE38U, 0xDBFC821CU, 0x2997011FU,
-        0x3AC7F2EBU, 0xC8AC71E8U, 0x1C661503U, 0xEE0D9600U, 0xFD5D65F4U,
-        0x0F36E6F7U, 0x61C69362U, 0x93AD1061U, 0x80FDE395U, 0x72966096U,
-        0xA65C047DU, 0x5437877EU, 0x4767748AU, 0xB50CF789U, 0xEB1FCBADU,
-        0x197448AEU, 0x0A24BB5AU, 0xF84F3859U, 0x2C855CB2U, 0xDEEEDFB1U,
-        0xCDBE2C45U, 0x3FD5AF46U, 0x7198540DU, 0x83F3D70EU, 0x90A324FAU,
-        0x62C8A7F9U, 0xB602C312U, 0x44694011U, 0x5739B3E5U, 0xA55230E6U,
-        0xFB410CC2U, 0x092A8FC1U, 0x1A7A7C35U, 0xE811FF36U, 0x3CDB9BDDU,
-        0xCEB018DEU, 0xDDE0EB2AU, 0x2F8B6829U, 0x82F63B78U, 0x709DB87BU,
-        0x63CD4B8FU, 0x91A6C88CU, 0x456CAC67U, 0xB7072F64U, 0xA457DC90U,
-        0x563C5F93U, 0x082F63B7U, 0xFA44E0B4U, 0xE9141340U, 0x1B7F9043U,
-        0xCFB5F4A8U, 0x3DDE77ABU, 0x2E8E845FU, 0xDCE5075CU, 0x92A8FC17U,
-        0x60C37F14U, 0x73938CE0U, 0x81F80FE3U, 0x55326B08U, 0xA759E80BU,
-        0xB4091BFFU, 0x466298FCU, 0x1871A4D8U, 0xEA1A27DBU, 0xF94AD42FU,
-        0x0B21572CU, 0xDFEB33C7U, 0x2D80B0C4U, 0x3ED04330U, 0xCCBBC033U,
-        0xA24BB5A6U, 0x502036A5U, 0x4370C551U, 0xB11B4652U, 0x65D122B9U,
-        0x97BAA1BAU, 0x84EA524EU, 0x7681D14DU, 0x2892ED69U, 0xDAF96E6AU,
-        0xC9A99D9EU, 0x3BC21E9DU, 0xEF087A76U, 0x1D63F975U, 0x0E330A81U,
-        0xFC588982U, 0xB21572C9U, 0x407EF1CAU, 0x532E023EU, 0xA145813DU,
-        0x758FE5D6U, 0x87E466D5U, 0x94B49521U, 0x66DF1622U, 0x38CC2A06U,
-        0xCAA7A905U, 0xD9F75AF1U, 0x2B9CD9F2U, 0xFF56BD19U, 0x0D3D3E1AU,
-        0x1E6DCDEEU, 0xEC064EEDU, 0xC38D26C4U, 0x31E6A5C7U, 0x22B65633U,
-        0xD0DDD530U, 0x0417B1DBU, 0xF67C32D8U, 0xE52CC12CU, 0x1747422FU,
-        0x49547E0BU, 0xBB3FFD08U, 0xA86F0EFCU, 0x5A048DFFU, 0x8ECEE914U,
-        0x7CA56A17U, 0x6FF599E3U, 0x9D9E1AE0U, 0xD3D3E1ABU, 0x21B862A8U,
-        0x32E8915CU, 0xC083125FU, 0x144976B4U, 0xE622F5B7U, 0xF5720643U,
-        0x07198540U, 0x590AB964U, 0xAB613A67U, 0xB831C993U, 0x4A5A4A90U,
-        0x9E902E7BU, 0x6CFBAD78U, 0x7FAB5E8CU, 0x8DC0DD8FU, 0xE330A81AU,
-        0x115B2B19U, 0x020BD8EDU, 0xF0605BEEU, 0x24AA3F05U, 0xD6C1BC06U,
-        0xC5914FF2U, 0x37FACCF1U, 0x69E9F0D5U, 0x9B8273D6U, 0x88D28022U,
-        0x7AB90321U, 0xAE7367CAU, 0x5C18E4C9U, 0x4F48173DU, 0xBD23943EU,
-        0xF36E6F75U, 0x0105EC76U, 0x12551F82U, 0xE03E9C81U, 0x34F4F86AU,
-        0xC69F7B69U, 0xD5CF889DU, 0x27A40B9EU, 0x79B737BAU, 0x8BDCB4B9U,
-        0x988C474DU, 0x6AE7C44EU, 0xBE2DA0A5U, 0x4C4623A6U, 0x5F16D052U,
-        0xAD7D5351U
-    };
-
-    for (size_t i = 0; i < len; i++) {
-        crc32val = crc32_tab[((uint8_t)crc32val) ^ ((uint8_t)s[i])] ^ (crc32val >> 8);
-    }
-    return crc32val;
-}
-
-
-static uint32_t hashmap_hash_helper_int_helper(const hashmap_t *const m,
-                                               const char *const keystring,
-                                               const size_t len)
+static size_t hashmap_hash_helper_int_helper(const hashmap_t *const m,
+                                             const char *const keystring,
+                                             const size_t len)
 {
     uint32_t key = hashmap_crc32_helper(keystring, len);
 
@@ -364,8 +345,9 @@ static int hashmap_match_helper(const struct hashmap_element *const element,
 static int hashmap_hash_helper(const hashmap_t *const m, const char *const key,
                                const size_t len, uint32_t *const out_index)
 {
-    unsigned int start, curr;
-    int total_in_use;
+    size_t curr = 0;
+    size_t first_empty = SIZE_MAX;
+    int total_in_use = 0;
 
     /* If full, return immediately */
     if (m->size >= m->table_size) {
@@ -373,39 +355,35 @@ static int hashmap_hash_helper(const hashmap_t *const m, const char *const key,
     }
 
     /* Find the best index */
-    curr = start = hashmap_hash_helper_int_helper(m, key, len);
+    curr = hashmap_hash_helper_int_helper(m, key, len);
 
     /* First linear probe to check if we've already insert the element */
     total_in_use = 0;
 
     for (int i = 0; i < HASHMAP_MAX_CHAIN_LENGTH; i++) {
-        const int in_use = m->data[curr].in_use;
+        if (m->data[curr].in_use) {
+            total_in_use++;
 
-        total_in_use += in_use;
-
-        if (in_use && hashmap_match_helper(&m->data[curr], key, len)) {
-            *out_index = curr;
-            return 1;
+            if (hashmap_match_helper(&m->data[curr], key, len)) {
+                /* exit if we found it. */
+                *out_index = curr;
+                return 1;
+            }
+        } else if (SIZE_MAX == first_empty) {
+            first_empty = curr;
         }
 
         curr = (curr + 1) % m->table_size;
     }
 
-    curr = start;
-
-    /* Second linear probe to actually insert our element (only if there was at
-   * least one empty entry) */
-    if (HASHMAP_MAX_CHAIN_LENGTH > total_in_use) {
-        for (int i = 0; i < HASHMAP_MAX_CHAIN_LENGTH; i++) {
-            if (!m->data[curr].in_use) {
-                *out_index = curr;
-                return 1;
-            }
-
-            curr = (curr + 1) % m->table_size;
-        }
+    /* Actually insert our element at the first found empty slot. */
+    if (SIZE_MAX != first_empty) {
+        /* exit if we found a place for it. */
+        *out_index = first_empty;
+        return 1;
     }
 
+    /* No room for the element. */
     return 0;
 }
 
@@ -414,7 +392,7 @@ static int hashmap_rehash_iterator(void *const new_hash,
                                    struct hashmap_element *const e)
 {
     int temp = hashmap_put((hashmap_t *)new_hash, e->key, e->key_len, e->data);
-    if (0 < temp) {
+    if (0 != temp) {
         return 1;
     }
     /* clear old value to avoid stale pointers */
@@ -428,28 +406,30 @@ static int hashmap_rehash_iterator(void *const new_hash,
 static int hashmap_rehash_helper(hashmap_t *const m)
 {
     /* If this multiplication overflows hashmap_create will fail. */
-    size_t new_size = 2 * m->table_size;
-
+    size_t new_size = 0;
+    int rv = 0;
     hashmap_t new_hash;
 
-    int flag = hashmap_create(new_size, &new_hash);
-
-    if (0 != flag) {
-        return flag;
+    if ((2 * m->size) < m->table_size) {
+        return -3;
     }
 
-    /* copy the old elements to the new table */
-    flag = hashmap_iterate_pairs(m, hashmap_rehash_iterator, &new_hash);
+    /* While this will result in doubling the size, this will not accidentally
+     * overflow the size. */
+    new_size = m->table_size + HASHMAP_DEFAULT_SIZE;
+    rv = hashmap_create(new_size, &new_hash);
+    if (0 == rv) {
 
-    if (0 != flag) {
-        return flag;
+        /* copy the old elements to the new table */
+        rv = hashmap_iterate_pairs(m, hashmap_rehash_iterator, &new_hash);
+        if (0 == rv) {
+
+            hashmap_destroy(m);
+            /* put new hash into old hash structure by copying */
+            memcpy(m, &new_hash, sizeof(hashmap_t));
+        }
     }
-
-    hashmap_destroy(m);
-    /* put new hash into old hash structure by copying */
-    memcpy(m, &new_hash, sizeof(hashmap_t));
-
-    return 0;
+    return rv;
 }
 
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -58,7 +58,7 @@ static int hashmap_match_helper(const struct hashmap_element *const element,
                                 const size_t len);
 static int hashmap_hash_helper(const hashmap_t *const m,
                                const char *const key, const size_t len,
-                               uint32_t *const out_index);
+                               size_t *const out_index);
 static int hashmap_rehash_iterator(void *const new_hash,
                                    struct hashmap_element *const e);
 static int hashmap_rehash_helper(hashmap_t *const m);
@@ -98,8 +98,7 @@ int hashmap_create(size_t initial_size, hashmap_t *const out_hashmap)
 int hashmap_put(hashmap_t *const m, const char *const key,
                 size_t len, void *const value)
 {
-    uint32_t index = 0;
-    int rv = 0;
+    size_t index = 0;
 
     if (!m) {
         return -1;
@@ -115,7 +114,7 @@ int hashmap_put(hashmap_t *const m, const char *const key,
 
     /* Find a place to put our value. */
     while (!hashmap_hash_helper(m, key, len, &index)) {
-        rv = hashmap_rehash_helper(m);
+        int rv = hashmap_rehash_helper(m);
         if (rv) {
             return rv;
         }
@@ -343,7 +342,7 @@ static int hashmap_match_helper(const struct hashmap_element *const element,
 
 
 static int hashmap_hash_helper(const hashmap_t *const m, const char *const key,
-                               const size_t len, uint32_t *const out_index)
+                               const size_t len, size_t *const out_index)
 {
     size_t curr = 0;
     size_t first_empty = SIZE_MAX;

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -409,7 +409,11 @@ static int hashmap_rehash_helper(hashmap_t *const m)
     int rv = 0;
     hashmap_t new_hash;
 
-    if ((2 * m->size) < m->table_size) {
+    /* If the hashmap is less than 75% full and we had a collision, then
+     * instead of increasing the number of buckets, we should fail out.
+     * This helps prevent run-away allocations due to a non-ideal hashing
+     * algorithm.*/
+    if (m->size < (3 * (m->table_size / 4))) {
         return -3;
     }
 

--- a/src/hashmap_crc.c
+++ b/src/hashmap_crc.c
@@ -1,0 +1,103 @@
+/* SPDX-FileCopyrightText: 2021 Comcast Cable Communications Management, LLC */
+/* SPDX-FileCopyrightText: 2021 Weston Schmidt */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/*----------------------------------------------------------------------------*/
+/*                                   Macros                                   */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                               Data Structures                              */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                            File Scoped Variables                           */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                             Function Prototypes                            */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                             Internal functions                             */
+/*----------------------------------------------------------------------------*/
+/* none */
+
+/*----------------------------------------------------------------------------*/
+/*                             External Functions                             */
+/*----------------------------------------------------------------------------*/
+
+extern uint32_t hashmap_crc32_helper(const char *const s, const size_t len)
+{
+    uint32_t crc32val = 0;
+
+    // Using polynomial 0x11EDC6F41 to match SSE 4.2's crc function.
+    static const uint32_t crc32_tab[] = {
+        0x00000000U, 0xF26B8303U, 0xE13B70F7U, 0x1350F3F4U, 0xC79A971FU,
+        0x35F1141CU, 0x26A1E7E8U, 0xD4CA64EBU, 0x8AD958CFU, 0x78B2DBCCU,
+        0x6BE22838U, 0x9989AB3BU, 0x4D43CFD0U, 0xBF284CD3U, 0xAC78BF27U,
+        0x5E133C24U, 0x105EC76FU, 0xE235446CU, 0xF165B798U, 0x030E349BU,
+        0xD7C45070U, 0x25AFD373U, 0x36FF2087U, 0xC494A384U, 0x9A879FA0U,
+        0x68EC1CA3U, 0x7BBCEF57U, 0x89D76C54U, 0x5D1D08BFU, 0xAF768BBCU,
+        0xBC267848U, 0x4E4DFB4BU, 0x20BD8EDEU, 0xD2D60DDDU, 0xC186FE29U,
+        0x33ED7D2AU, 0xE72719C1U, 0x154C9AC2U, 0x061C6936U, 0xF477EA35U,
+        0xAA64D611U, 0x580F5512U, 0x4B5FA6E6U, 0xB93425E5U, 0x6DFE410EU,
+        0x9F95C20DU, 0x8CC531F9U, 0x7EAEB2FAU, 0x30E349B1U, 0xC288CAB2U,
+        0xD1D83946U, 0x23B3BA45U, 0xF779DEAEU, 0x05125DADU, 0x1642AE59U,
+        0xE4292D5AU, 0xBA3A117EU, 0x4851927DU, 0x5B016189U, 0xA96AE28AU,
+        0x7DA08661U, 0x8FCB0562U, 0x9C9BF696U, 0x6EF07595U, 0x417B1DBCU,
+        0xB3109EBFU, 0xA0406D4BU, 0x522BEE48U, 0x86E18AA3U, 0x748A09A0U,
+        0x67DAFA54U, 0x95B17957U, 0xCBA24573U, 0x39C9C670U, 0x2A993584U,
+        0xD8F2B687U, 0x0C38D26CU, 0xFE53516FU, 0xED03A29BU, 0x1F682198U,
+        0x5125DAD3U, 0xA34E59D0U, 0xB01EAA24U, 0x42752927U, 0x96BF4DCCU,
+        0x64D4CECFU, 0x77843D3BU, 0x85EFBE38U, 0xDBFC821CU, 0x2997011FU,
+        0x3AC7F2EBU, 0xC8AC71E8U, 0x1C661503U, 0xEE0D9600U, 0xFD5D65F4U,
+        0x0F36E6F7U, 0x61C69362U, 0x93AD1061U, 0x80FDE395U, 0x72966096U,
+        0xA65C047DU, 0x5437877EU, 0x4767748AU, 0xB50CF789U, 0xEB1FCBADU,
+        0x197448AEU, 0x0A24BB5AU, 0xF84F3859U, 0x2C855CB2U, 0xDEEEDFB1U,
+        0xCDBE2C45U, 0x3FD5AF46U, 0x7198540DU, 0x83F3D70EU, 0x90A324FAU,
+        0x62C8A7F9U, 0xB602C312U, 0x44694011U, 0x5739B3E5U, 0xA55230E6U,
+        0xFB410CC2U, 0x092A8FC1U, 0x1A7A7C35U, 0xE811FF36U, 0x3CDB9BDDU,
+        0xCEB018DEU, 0xDDE0EB2AU, 0x2F8B6829U, 0x82F63B78U, 0x709DB87BU,
+        0x63CD4B8FU, 0x91A6C88CU, 0x456CAC67U, 0xB7072F64U, 0xA457DC90U,
+        0x563C5F93U, 0x082F63B7U, 0xFA44E0B4U, 0xE9141340U, 0x1B7F9043U,
+        0xCFB5F4A8U, 0x3DDE77ABU, 0x2E8E845FU, 0xDCE5075CU, 0x92A8FC17U,
+        0x60C37F14U, 0x73938CE0U, 0x81F80FE3U, 0x55326B08U, 0xA759E80BU,
+        0xB4091BFFU, 0x466298FCU, 0x1871A4D8U, 0xEA1A27DBU, 0xF94AD42FU,
+        0x0B21572CU, 0xDFEB33C7U, 0x2D80B0C4U, 0x3ED04330U, 0xCCBBC033U,
+        0xA24BB5A6U, 0x502036A5U, 0x4370C551U, 0xB11B4652U, 0x65D122B9U,
+        0x97BAA1BAU, 0x84EA524EU, 0x7681D14DU, 0x2892ED69U, 0xDAF96E6AU,
+        0xC9A99D9EU, 0x3BC21E9DU, 0xEF087A76U, 0x1D63F975U, 0x0E330A81U,
+        0xFC588982U, 0xB21572C9U, 0x407EF1CAU, 0x532E023EU, 0xA145813DU,
+        0x758FE5D6U, 0x87E466D5U, 0x94B49521U, 0x66DF1622U, 0x38CC2A06U,
+        0xCAA7A905U, 0xD9F75AF1U, 0x2B9CD9F2U, 0xFF56BD19U, 0x0D3D3E1AU,
+        0x1E6DCDEEU, 0xEC064EEDU, 0xC38D26C4U, 0x31E6A5C7U, 0x22B65633U,
+        0xD0DDD530U, 0x0417B1DBU, 0xF67C32D8U, 0xE52CC12CU, 0x1747422FU,
+        0x49547E0BU, 0xBB3FFD08U, 0xA86F0EFCU, 0x5A048DFFU, 0x8ECEE914U,
+        0x7CA56A17U, 0x6FF599E3U, 0x9D9E1AE0U, 0xD3D3E1ABU, 0x21B862A8U,
+        0x32E8915CU, 0xC083125FU, 0x144976B4U, 0xE622F5B7U, 0xF5720643U,
+        0x07198540U, 0x590AB964U, 0xAB613A67U, 0xB831C993U, 0x4A5A4A90U,
+        0x9E902E7BU, 0x6CFBAD78U, 0x7FAB5E8CU, 0x8DC0DD8FU, 0xE330A81AU,
+        0x115B2B19U, 0x020BD8EDU, 0xF0605BEEU, 0x24AA3F05U, 0xD6C1BC06U,
+        0xC5914FF2U, 0x37FACCF1U, 0x69E9F0D5U, 0x9B8273D6U, 0x88D28022U,
+        0x7AB90321U, 0xAE7367CAU, 0x5C18E4C9U, 0x4F48173DU, 0xBD23943EU,
+        0xF36E6F75U, 0x0105EC76U, 0x12551F82U, 0xE03E9C81U, 0x34F4F86AU,
+        0xC69F7B69U, 0xD5CF889DU, 0x27A40B9EU, 0x79B737BAU, 0x8BDCB4B9U,
+        0x988C474DU, 0x6AE7C44EU, 0xBE2DA0A5U, 0x4C4623A6U, 0x5F16D052U,
+        0xAD7D5351U
+    };
+
+    for (size_t i = 0; i < len; i++) {
+        crc32val = crc32_tab[((uint8_t)crc32val) ^ ((uint8_t)s[i])] ^ (crc32val >> 8);
+    }
+    return crc32val;
+}
+

--- a/tests/test_hashmap.c
+++ b/tests/test_hashmap.c
@@ -21,24 +21,30 @@ static int set_context(void *const context, void *const element)
 
 void test_create()
 {
-    struct hashmap_s h;
+    hashmap_t h;
 
     CU_ASSERT(0 == hashmap_create(1, &h));
     hashmap_destroy(&h);
 }
 
+extern size_t num_to_pow2(size_t);
 
 void test_create_boundary()
 {
-    struct hashmap_s h;
+    hashmap_t h;
 
-    CU_ASSERT(0 != hashmap_create(0, &h));
-    CU_ASSERT(0 != hashmap_create(3, &h));
+    CU_ASSERT(0 == hashmap_create(0, &h));
+    hashmap_destroy(&h);
+
+    CU_ASSERT(0 == hashmap_create(3, &h));
+    hashmap_destroy(&h);
+
+    CU_ASSERT(0 != hashmap_create(0x80000001, &h));
 }
 
 void test_put()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
     int y = 13;
 
@@ -53,7 +59,7 @@ void test_put()
 
 void test_put_twice()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
     int y = 13;
 
@@ -70,7 +76,7 @@ void test_put_twice()
 
 void test_get_exists()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
     int *y;
 
@@ -85,7 +91,7 @@ void test_get_exists()
 
 void test_get_does_not_exists()
 {
-    struct hashmap_s h;
+    hashmap_t h;
 
     CU_ASSERT(0 == hashmap_create(1, &h));
     CU_ASSERT(NULL == hashmap_get(&h, "foo", 3));
@@ -96,7 +102,7 @@ void test_get_does_not_exists()
 
 void test_remove()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
     CU_ASSERT(0 == hashmap_create(1, &h));
     CU_ASSERT(0 == hashmap_put(&h, "foo", 3, &x));
@@ -110,7 +116,7 @@ void test_remove_and_return_key()
      * used later. */
     const char *const key = "foo&bar";
 
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
 
     CU_ASSERT(0 == hashmap_create(1, &h));
@@ -133,7 +139,7 @@ static int early_exit(void *const context, void *const element)
 
 void test_iterate_early_exit()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x[27] = { 0 };
     int total = 0;
     char s[27];
@@ -177,7 +183,7 @@ static int all(void *const context, void *const element)
 
 void test_iterate_all()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x[27] = { 0 };
     int total = 0;
     char s[27];
@@ -206,7 +212,7 @@ void test_iterate_all()
 
 void test_num_entries()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x = 42;
     CU_ASSERT(0 == hashmap_create(1, &h));
     CU_ASSERT(0 == hashmap_num_entries(&h));
@@ -217,7 +223,7 @@ void test_num_entries()
     hashmap_destroy(&h);
 }
 
-static int rem_all(void *context, struct hashmap_element_s *e)
+static int rem_all(void *context, struct hashmap_element *e)
 {
     (*(int *)context) += e->key_len;
     return -1;
@@ -225,7 +231,7 @@ static int rem_all(void *context, struct hashmap_element_s *e)
 
 void test_remove_all()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int x[27] = { 0 };
     int total = 0;
     char s[27];
@@ -251,7 +257,7 @@ void test_remove_all()
 
 void test_hash_conflict()
 {
-    struct hashmap_s h;
+    hashmap_t h;
 
     int x = 42;
     int y = 13;
@@ -280,7 +286,7 @@ void test_hash_conflict()
 
 void test_issue_20()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     const char *key = "192.168.2.2hv_api.udache.com/abc/def";
     unsigned int len = sizeof(key) - 1;
 
@@ -300,7 +306,7 @@ void test_issue_20()
 
 void simple_test()
 {
-    struct hashmap_s h;
+    hashmap_t h;
     int z = 5;
     int y = 4;
     int x = 3;

--- a/tests/test_hashmap_collision.c
+++ b/tests/test_hashmap_collision.c
@@ -1,0 +1,83 @@
+/* SPDX-FileCopyrightText: 2020 Neil Henning, et. al*/
+/* SPDX-License-Identifier: Unlicense */
+
+/*
+ * Copied from https://github.com/sheredom/hashmap.h/blob/master/test/test.c
+ * and modified to work in this build ecosystem.
+ */
+#include <CUnit/Basic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hashmap.h"
+
+uint32_t hashmap_crc32_helper(const char *const s, const size_t len)
+{
+    (void)s;
+    (void)len;
+
+    /* Always hash to the same slot to fill the hashmap up at just
+     * the one slot. */
+    return 0;
+}
+
+
+void test_collision()
+{
+    hashmap_t h;
+    int ignored = 0;
+
+    CU_ASSERT(0 == hashmap_create(16, &h));
+    CU_ASSERT(0 == hashmap_put(&h, "foo", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "bar", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "goo", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "cat", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "dog", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "dag", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "egg", 3, &ignored));
+    CU_ASSERT(0 == hashmap_put(&h, "axe", 3, &ignored));
+    CU_ASSERT(0 != hashmap_put(&h, "fog", 3, &ignored));
+    CU_ASSERT(NULL != hashmap_get(&h, "axe", 3));
+    CU_ASSERT(NULL == hashmap_get(&h, "fog", 3));
+    hashmap_destroy(&h);
+}
+
+
+void add_suites(CU_pSuite *suite)
+{
+    *suite = CU_add_suite("hashmap.c tests", NULL, NULL);
+    CU_add_test(*suite, "Collision Test", test_collision);
+}
+
+
+/*----------------------------------------------------------------------------*/
+/*                             External Functions                             */
+/*----------------------------------------------------------------------------*/
+int main(void)
+{
+    unsigned rv = 1;
+    CU_pSuite suite = NULL;
+
+    if (CUE_SUCCESS == CU_initialize_registry()) {
+        add_suites(&suite);
+
+        if (NULL != suite) {
+            CU_basic_set_mode(CU_BRM_VERBOSE);
+            CU_basic_run_tests();
+            printf("\n");
+            CU_basic_show_failures(CU_get_failure_list());
+            printf("\n\n");
+            rv = CU_get_number_of_tests_failed();
+        }
+
+        CU_cleanup_registry();
+    }
+
+    if (0 != rv) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Change the hashmap struct into a typedef hashmap_t for less verbosity.
- Change the `struct hashmap_element_s` to be `struct hashmap_element`.
- Remove `const` from numeric values.
- Change the initial size to accept any value to make usage easier.
- Guard against an overflow size.